### PR TITLE
[PDMVDEV-32] Change SMTP server

### DIFF
--- a/utils/emailer.py
+++ b/utils/emailer.py
@@ -44,8 +44,7 @@ class Emailer():
         message['From'] = 'PdmV Service Account <pdmvserv@cern.ch>'
         message['To'] = ', '.join(recipients)
         message['Cc'] = 'pdmvserv@cern.ch'
-        # Send the message via our own SMTP server.
-        smtp = smtplib.SMTP()
+        smtp = smtplib.SMTP(host="cernmx.cern.ch", port=25)
         smtp.connect()
         self.logger.debug('Sending email %s to %s', message['Subject'], message['To'])
         smtp.send_message(message)


### PR DESCRIPTION
Current SMTP server, smtp.cern.ch, is going to be decomissioned on June 30, 2023.