### PR TITLE
Delete connect() instruction

### DIFF
--- a/utils/emailer.py
+++ b/utils/emailer.py
@@ -45,7 +45,6 @@ class Emailer():
         message['To'] = ', '.join(recipients)
         message['Cc'] = 'pdmvserv@cern.ch'
         smtp = smtplib.SMTP(host="cernmx.cern.ch", port=25)
-        smtp.connect()
         self.logger.debug('Sending email %s to %s', message['Subject'], message['To'])
         smtp.send_message(message)
         smtp.quit()


### PR DESCRIPTION
By default, this instruction overwrites the configuration given when the SMTP client is created, this leads to try open connections to `localhost`. For details, please see: [SMTP Connect](https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.connect)