### PR TITLE
Include support to use Kerberos tickets for SSH authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Just for reference
 Flask==2.2.3
 Flask-RESTful==0.3.9
 pymongo==3.13.0
@@ -7,3 +8,5 @@ cryptography==39.0.1
 requests==2.31.0
 Werkzeug==2.2.3
 paramiko==3.0.0
+gssapi>=1.8.3
+pyasn1>=0.5.1 


### PR DESCRIPTION
1. Include GSSAPI support for the `SSHExecutor` module.
2. In case a Kerberos ticket is not available, the `password` authentication method will be used. This was the current behavior.